### PR TITLE
csvlint: Add csvlint engine

### DIFF
--- a/engines/csvlint/Dockerfile
+++ b/engines/csvlint/Dockerfile
@@ -1,0 +1,11 @@
+FROM linterhub/image-ruby
+LABEL maintainer="linterhub@repometric.com"
+RUN apk add --no-cache libcurl && \
+    apk add --no-cache --virtual .build-deps \
+    make \
+    ruby-dev \
+    gcc \
+    musl-dev \
+    libffi-dev && \
+    gem install csvlint && \
+    apk del .build-deps

--- a/engines/csvlint/docker-compose.test.yml
+++ b/engines/csvlint/docker-compose.test.yml
@@ -1,0 +1,6 @@
+sut:
+  build: .
+  volumes:
+    - ./tests:/tests:ro
+  working_dir: /tests
+  command: sh run_compare.sh

--- a/engines/csvlint/tests/expected.txt
+++ b/engines/csvlint/tests/expected.txt
@@ -1,0 +1,4 @@
+[0;32;49m.[0m[0;31;49m![0m[0;32;49m.[0m[0;32;49m.[0m
+test.csv is INVALID
+1. blank_rows. Row: 2. 
+2. line_breaks

--- a/engines/csvlint/tests/run_compare.sh
+++ b/engines/csvlint/tests/run_compare.sh
@@ -1,0 +1,10 @@
+actual=$(sh run_tests.sh)
+expected=$(cat expected.txt)
+
+if [ "$actual" == "$expected" ]
+then
+  echo "OK"
+else
+  echo -e "ERROR\n Actual:"$actual"\nExpected:"$expected
+  exit 1
+fi

--- a/engines/csvlint/tests/run_tests.sh
+++ b/engines/csvlint/tests/run_tests.sh
@@ -1,0 +1,1 @@
+csvlint test.csv

--- a/engines/csvlint/tests/test.csv
+++ b/engines/csvlint/tests/test.csv
@@ -1,0 +1,4 @@
+"Foo","Bsr","Baz"
+
+"Biff","Baff","Boff"
+"Qux","Teaspoon","Doge"

--- a/images/ruby/Dockerfile
+++ b/images/ruby/Dockerfile
@@ -1,0 +1,3 @@
+FROM ruby:alpine
+LABEL maintainer="linterhub@repometric.com"
+ENTRYPOINT /bin/sh


### PR DESCRIPTION
Adds missing csvlint using ruby image.

Closes https://github.com/repometric/linterhub-docker/issues/10