### PR TITLE
Add stylint engine

### DIFF
--- a/engines/stylint/Dockerfile
+++ b/engines/stylint/Dockerfile
@@ -1,0 +1,3 @@
+FROM linterhub/image-npm
+LABEL maintainer="linterhub@repometric.com"
+RUN npm install -g stylint

--- a/engines/stylint/docker-compose.test.yml
+++ b/engines/stylint/docker-compose.test.yml
@@ -1,0 +1,6 @@
+sut:
+  build: .
+  volumes:
+    - ./tests:/tests:ro
+  working_dir: /tests
+  command: sh run_compare.sh

--- a/engines/stylint/tests/expected.txt
+++ b/engines/stylint/tests/expected.txt
@@ -1,0 +1,16 @@
+sample.styl
+1:7   warning  unnecessary bracket                          brackets  
+2:19  warning  unnecessary semicolon found                  semicolons
+3:19  warning  unnecessary semicolon found                  semicolons
+4     warning  unnecessary bracket                          brackets  
+7:8   warning  missing colon between property and value     colons    
+8:3   warning  missing colon between property and value     colons    
+9:5   warning  missing colon between property and value     colons    
+9     warning  prefer alphabetical when sorting properties  sortOrder 
+10:7  warning  missing colon between property and value     colons    
+10    warning  prefer alphabetical when sorting properties  sortOrder 
+11:5  warning  missing colon between property and value     colons    
+11    warning  prefer alphabetical when sorting properties  sortOrder 
+
+Stylint: 0 Errors.
+Stylint: 12 Warnings.

--- a/engines/stylint/tests/run_compare.sh
+++ b/engines/stylint/tests/run_compare.sh
@@ -1,0 +1,9 @@
+actual=$(sh run_tests.sh)
+expected=$(cat expected.txt)
+if [ "$actual" == "$expected" ]
+then
+    echo "OK"
+else
+    echo -e "ERROR\n Actual:"$actual"\nExpected:"$expected
+    exit 1
+fi

--- a/engines/stylint/tests/run_tests.sh
+++ b/engines/stylint/tests/run_tests.sh
@@ -1,0 +1,1 @@
+stylint sample.styl

--- a/engines/stylint/tests/sample.styl
+++ b/engines/stylint/tests/sample.styl
@@ -1,0 +1,11 @@
+button {
+	background-image: url('path/to/png.png');
+    cursor: pointer;
+}
+
+.some-class
+	position absolute
+	top 0
+	right 10px
+	display block
+	float left


### PR DESCRIPTION
Adds missing stylint engine using existing `image-npm`.

Closes #19 